### PR TITLE
fix: mainMenu.css defined width and grid-area

### DIFF
--- a/src/components/mainMenu/mainMenu.css
+++ b/src/components/mainMenu/mainMenu.css
@@ -7,6 +7,8 @@
   box-shadow: 0 4px 4px rgb(0, 0, 0, 0.25), 4px 4px 40px rgb(255, 0, 0, 0.9);
   border-radius: 16px;
   height: 11.25rem;
+  width: 100%;
+  grid-area: modeMenu;
 }
 
 .swquiz-mainmenu-item {


### PR DESCRIPTION
Added to .swquiz-mainmenu
width: 100%
grid-area: modeMenu
